### PR TITLE
Transform::process() now transforms bitangents as well as normals and…

### DIFF
--- a/src/cinder/GeomIo.cpp
+++ b/src/cinder/GeomIo.cpp
@@ -2733,7 +2733,7 @@ void Transform::process( SourceModsContext *ctx, const AttribSet &requestedAttri
 	else if( ctx->getAttribDims( POSITION ) != 0 )
 		CI_LOG_W( "Unsupported dimension for geom::POSITION passed to geom::Transform" );
 	
-	// we'll make the sort of modification to our normals (if they're present)
+	// we'll make the same sort of modification to our normals (if they're present)
 	// using the inverse transpose of 'mTransform'
 	if( ctx->getAttribDims( NORMAL ) == 3 ) {
 		vec3* normals = reinterpret_cast<vec3*>( ctx->getAttribData( NORMAL ) );
@@ -2744,7 +2744,7 @@ void Transform::process( SourceModsContext *ctx, const AttribSet &requestedAttri
 	else if( ctx->getAttribDims( NORMAL ) != 0 )
 		CI_LOG_W( "Unsupported dimension for geom::NORMAL passed to geom::Transform" );
 
-	// and finally, we'll make the sort of modification to our tangents (if they're present)
+	// we'll also make the same sort of modification to our tangents (if they're present)
 	// using the inverse transpose of 'mTransform'
 	if( ctx->getAttribDims( TANGENT ) == 3 ) {
 		vec3* tangents = reinterpret_cast<vec3*>( ctx->getAttribData( TANGENT ) );
@@ -2754,6 +2754,17 @@ void Transform::process( SourceModsContext *ctx, const AttribSet &requestedAttri
 	}
 	else if( ctx->getAttribDims( TANGENT ) != 0 )
 		CI_LOG_W( "Unsupported dimension for geom::TANGENT passed to geom::Transform" );
+
+	// and finally, we'll make the same sort of modification to our bitangents (if they're present)
+	// using the inverse transpose of 'mTransform'
+	if( ctx->getAttribDims( BITANGENT ) == 3 ) {
+		vec3* bitangents = reinterpret_cast<vec3*>( ctx->getAttribData( BITANGENT ) );
+		mat3 bitangentsTransform = glm::transpose( inverse( mat3( mTransform ) ) );
+		for( size_t v = 0; v < numVertices; ++v )
+			bitangents[v] = normalize( bitangentsTransform * bitangents[v] );
+	}
+	else if( ctx->getAttribDims( BITANGENT ) != 0 )
+		CI_LOG_W( "Unsupported dimension for geom::BITANGENT passed to geom::Transform" );
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
… tangents

Bitangents were being ignored in void Transform::process( SourceModsContext *ctx, const AttribSet &requestedAttribs ) const.  This change transforms the bitangents in the same way that normals and tangents are already transformed.  Also, there are some minor changes to the comments.

Note that the same vector inverse transformation -- for example, mat3 normalsTransform = glm::transpose( inverse( mat3( mTransform ) ) ); -- is computed three times, once each for normals, tangents, and bitangents.  I have not optimized this out since I did not want to introduce a compound change.